### PR TITLE
Update the selected publications according to Bob's suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,36 +134,52 @@
             </p>
         </div>
         <div id="introPublications" class="row cell">
-            <h2>Selected publications</h2>
+            <h2>Have a taste of ZX-calculus</h2>
             <p>
                 We show here a couple of papers that might serve as good introductions to the ZX-calculus. Please see
                 the <a href="/publications.html">publications page</a> for a full list of papers using the ZX-calculus.
             </p>
             <ul>
                 <li>
+                    <a href="https://arxiv.org/abs/2303.03163">
+                        Basic ZX-calculus for students and professionals:
+                    </a>
+                    the shortest path if you know some Dirac notation.
+                </li>
+                <li>
+                    <a href="https://arxiv.org/abs/2102.10984">
+                        Kindergarden quantum mechanics graduates:
+                    </a>
+                    a glimpse of some recent practical developments.
+                </li>
+                <li>
                     <a href="https://arxiv.org/abs/2012.13966">
-                        ZX-calculus for the working quantum computer scientist
+                        ZX-calculus for the working quantum computer scientist:
                     </a>
-                    (2020). A review of the literature on the ZX-calculus together with an extended introduction.
+                    tutorial on ZX at the cutting-edge of quantum computing.
                 </li>
+            </ul>
+        </div>
+        <div id="introBooks" class="row cell">
+            <h2>Books on ZX-calculus</h2>
+            <ul>
                 <li>
-                    <a href="https://arxiv.org/abs/1902.03178">
-                        Graph-theoretic Simplification of Quantum Circuits with the ZX-calculus
+                    <a href="https://www.amazon.co.uk/Quantum-Pictures-New-Understand-World/dp/1739214714">
+                        Quantum in Pictures:
                     </a>
-                    (2019). This paper demonstrates a use-case of the ZX-calculus: quantum circuit optimisation.
-                </li>
-                <li>
-                    <a href="https://arxiv.org/abs/1812.09114">
-                        A Near-Optimal Axiomatisation of ZX-Calculus for Pure Qubit Quantum Mechanics
-                    </a>
-                    (2018). This paper established the simplest complete axiomatisation of the ZX-calculus.
+                    no math prerequisites whatsoever.
                 </li>
                 <li>
                     <a href="https://www.amazon.com/Picturing-Quantum-Processes-Diagrammatic-Reasoning/dp/110710422X">
-                        Picturing Quantum Processes: A First Course in Quantum Theory and Diagrammatic Reasoning
+                        Picturing Quantum Processes:
                     </a>
-                    (2017). This extensive book explains quantum theory using a diagrammatic method that ultimately
-                    leads one to the ZX-calculus.
+                    the bible of (quantum) diagrammatic reasoning
+                </li>
+                <li>
+                    <a href="https://www.amazon.co.uk/Categories-Quantum-Theory-Introduction-Mathematics/dp/0198739613">
+                        Categories for Quantum Theory:
+                    </a>
+                    all in terms of category theory
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Bob's email according to which the changes have been made:

Had a look at the ZX-page and in the light how broad the popularity is becoming among potentially interested young researchers, people at business/evangelise side etc it is a little outdated on some fronts, and not entirely inclusive.  It shows up first in any search for ZX, even before the wiki, so needs some improving.


The most outdated would be the example papers, which may scare more people away than attract, as none of them really can be called a `taster’.  John’s tutorial is really for someone who actively wants to use ZX at the cutting-edge of quantum computing, and in the dodo book you need to swallow 500 pages before getting at ZX.  I suggest the following structure in order to augment inclusivity: 


1) Have a taste of ZX-calculus:

- Basic ZX-calculus: the shortest path if you know some Dirac notation

- Kindergarten QM graduates: a glimpse of some recent practical developments

- John’s: tutorial on ZX at the cutting-edge of QC


2) Books on ZX-calculus:

- QiP: no math prerequisites whatsoever

- PQP: the bible of (quantum) diagrammatic reasoning

- Chris/Jamie: all in terms of category theory


https://zxcalculus.com/intro.html is ok but shouldn’t be called an introduction as it doesn’t even list hopf or anything.  It’s more like “trailer”.


Regarding the two other listed papers, there are now so many applications that only listing circuit optimisation is too inward looking.  Such example technical papers should include at least one team that are not “us”, e.g. the latest PsiQuantum paper and Shor's paper.    


Only listing Renaud for completeness also isn’t fair on others.  If anything is mentioned on completeness you’d expect a paragraph first explaining in simple terms what it is, as a slogan or so: “ZX-can produce any equation that you can obtain in Hilbert space”, and then maybe Miriam, Amar-Harny-KF, and then Renaud.  

